### PR TITLE
Allow warming more than one host at a time

### DIFF
--- a/varnish-cache-warmer.sh
+++ b/varnish-cache-warmer.sh
@@ -2,18 +2,32 @@
 #
 # Written by AC - 2015 <al@terraltech.com> - sys0dm1n.com
 #
-URL='website.com'
+# The URL variable can be a list of 1 or more domains and IPs
+# When using more than 1 host, make sure to seperate
+# the different hosts by a space character
+# For example: URL=('example.com' '127.0.0.1')
+#                    or: URL=('example.com')
+#                    or: URL=('127.0.0.1')
+URL=('website.com')
 
-wget --quiet http://$URL/sitemap.xml --no-cache --output-document - | egrep -o "http(s?)://$URL[^ \"\'()\<>]+" | while read line; do
-    if [[ $line == *.xml ]]
-    then
-        newURL=$line
-        wget --quiet $newURL --no-cache --output-document - | egrep -o "http(s?)://$URL[^ \"\'()\<>]+" | while read newline; do
-           time curl -A 'Cache Warmer' -sL -w "%{http_code} %{url_effective}\n" $newline -o /dev/null 2>&1
-           echo $newline
-         done
-    else
-         time curl -A 'Cache Warmer' -sL -w "%{http_code} %{url_effective}\n" $line -o /dev/null 2>&1
-         echo $line
-     fi
+warm_varnish() {
+    echo "Warming cache for $1"
+    wget --quiet http://$1/sitemap.xml --no-cache --output-document - | egrep -o "http(s?)://$1[^ \"\'()\<>]+" | while read line; do
+        if [[ $line == *.xml ]]
+        then
+            newURL=$line
+            wget --quiet $newURL --no-cache --output-document - | egrep -o "http(s?)://$1[^ \"\'()\<>]+" | while read newline; do
+                time curl -A 'Cache Warmer' -sL -w "%{http_code} %{url_effective}\n" $newline -o /dev/null 2>&1
+                echo $newline
+            done
+        else
+            time curl -A 'Cache Warmer' -sL -w "%{http_code} %{url_effective}\n" $line -o /dev/null 2>&1
+            echo $line
+        fi
+    done
+    echo "Done warming cache for $1"
+}
+
+for host in "${URL[@]}"; do
+    warm_varnish $host
 done


### PR DESCRIPTION
In response to #1.
This would allow you to input more than one 1 host.

However, I think a couple of improvements can still be made.

1. Allow passing 1 or more hosts from the command line directly instead of changing it in the file every time.
2. At line 19, maybe call `warm_varnish` again and make the function recursive. This would support sitemaps that are more than 2 levels deep.