### PR TITLE
Follow rfc7231 for the User-Agent string

### DIFF
--- a/varnish-cache-warmer.sh
+++ b/varnish-cache-warmer.sh
@@ -5,18 +5,21 @@
 # The URLs or IPs variables are passed as an argument to the script like below:
 # ./varnish-cache-warmer.sh example1.com example2.com example3.com
 
+VERSION='1.0.0'
+USER_AGENT="VarnishCacheWarmer/$VERSION (see https://github.com/sys0dm1n/varnish-cache-warmer)"
+
 warm_varnish() {
     echo "Warming cache for $1"
-    curl -sL -A 'Cache Warmer' http://$1/sitemap.xml | egrep -o "http(s?)://$1[^ \"\'()\<>]+" | while read line; do
+    curl -sL -A "$USER_AGENT" http://$1/sitemap.xml | egrep -o "http(s?)://$1[^ \"\'()\<>]+" | while read line; do
         if [[ $line == *.xml ]]
         then
             newURL=$line
-            curl -sL -A 'Cache Warmer' $newURL | egrep -o "http(s?)://$1[^ \"\'()\<>]+" | while read newline; do
-                time curl -sL -A 'Cache Warmer' -sL -w "%{http_code} %{url_effective}\n" $newline -o /dev/null 2>&1
+            curl -sL -A "$USER_AGENT" $newURL | egrep -o "http(s?)://$1[^ \"\'()\<>]+" | while read newline; do
+                time curl -sL -A "$USER_AGENT" -sL -w "%{http_code} %{url_effective}\n" $newline -o /dev/null 2>&1
                 echo $newline
             done
         else
-            time curl -sL -A 'Cache Warmer' -sL -w "%{http_code} %{url_effective}\n" $line -o /dev/null 2>&1
+            time curl -sL -A "$USER_AGENT" -sL -w "%{http_code} %{url_effective}\n" $line -o /dev/null 2>&1
             echo $line
         fi
     done


### PR DESCRIPTION
This resolves #7 by using a User-Agent string that follows the standard format defined in [RFC 7231](https://tools.ietf.org/html/rfc7231#section-5.5.3).

Currently using the following:
```
Product/Version (Comment)
```